### PR TITLE
Added a reference to common.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>DID Method Rubric v1.0</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" defer="defer" class="remove"></script>
+    <script class='remove' src="./common.js"></script>
     <script class='remove'>
       // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
       var respecConfig = {
@@ -29,6 +30,9 @@
 
         // automatically allow term pluralization
         pluralize: true,
+        
+        // extend the bibliography entries
+        localBiblio: ccg.localBiblio,
 
         github: {
             repoURL: "https://github.com/w3c/did-rubric/",


### PR DESCRIPTION
Added a reference to `common.js` into the respec configuration to allow for the DID-DEC-RUBRIC reference to work.

I would also advise you to change `common.js` by removing the DID-SPEC-REGISTRIES entry. This entry freezes an earlier version; let the respec mechanism work using the online database to pick up the latest version instead.